### PR TITLE
Add history for widgets

### DIFF
--- a/src/screens/widget.jsx
+++ b/src/screens/widget.jsx
@@ -6,47 +6,69 @@ import { authContext } from "../AuthProvider";
 export default function Widget(props) {
   const { state, setState } = useContext(authContext);
   const { widgetID } = useParams();
-
-  // Set local widget state
-  const [widget, setWidget] = useState({});
+  const [ widget, setWidget ] = useState({
+    details: {},
+    history: []
+  })
 
   // Axios request using widgetID from params to get
-  // widget details, then setWidget to the returned data
+  // widget details and widget history
   useEffect(() => {
-    axios.get(`/widgets/${widgetID}`).then((response) => {
-      console.log(response.data);
-      setWidget(response.data);
+    axios.get(`/widgets/${widgetID}`)
+    .then(all => {
+      const [ detailsResponse, historyResponse ] = all.data;
+      // Order the history objects by id (oldest first, newest last)
+      const sortedResponseData = historyResponse.sort((a, b) => a.id - b.id);
+      setWidget(prev => ({
+        ...prev, 
+        details: detailsResponse,
+        history: sortedResponseData
+      }))
     });
   }, [widgetID]);
 
   const addToCart = () => {
     // Add this widget's id to state.itemsInCart
     const currentCart = [...state.itemsInCart];
-    currentCart.push(widget.id);
+    currentCart.push(widget.details.id);
     setState((prev) => ({
       ...prev,
       itemsInCart: currentCart,
     }));
-    console.log("stateystate", state);
   };
+
+  const displayWidgetHistory = widget.history.map(historyData => {
+    return (
+      <ul key={historyData.id}>
+        <li>Date Purchased: {historyData.date_purchased}</li>
+        <li>By: {historyData.email} (userID: {historyData.id})</li>
+        <li>Bought For: ${historyData.bought_for_price_cents / 100}</li>
+      </ul>
+    );
+  });
 
   return (
     <div>
       <h3>Widget ID is #{widgetID}</h3>
       <ul>
-        <li>Name: {widget.name}</li>
-        <li> {widget.imgurl}</li>
-        <li>Description: {widget.description}</li>
-        <li>id: {widget.id}</li>
-        <li>hash: {widget.hash}</li>
-        <li>MSRP: {widget.msrp_cents}</li>
-        <li>Rarity_id:{widget.rarity_id}</li>
-        <li>Subcategory_id: {widget.subcategory_id}</li>
-        <li>For_sale_by_owner: {widget.for_sale_by_owner}</li>
-        <li>Current_sell_price_cents: {widget.current_sell_price_cents}</li>
+        <li>Name: {widget.details.name}</li>
+        <li>imgurl: {widget.details.imgurl}</li>
+        <li>Description: {widget.details.description}</li>
+        <li>id: {widget.details.id}</li>
+        <li>hash: {widget.details.hash}</li>
+        <li>MSRP: {widget.details.msrp_cents}</li>
+        <li>Rarity_id:{widget.details.rarity_id}</li>
+        <li>Subcategory_id: {widget.details.subcategory_id}</li>
+        <li>For_sale_by_owner: {widget.details.for_sale_by_owner}</li>
+        <li>Current_sell_price_cents: {widget.details.current_sell_price_cents}</li>
       </ul>
 
       <button onClick={addToCart}>Add to Cart</button>
+
+      <div>
+        <h3>History</h3>
+          {displayWidgetHistory}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The backend route for get /widgets/:id was updated to provide not only the widgets information, but now also the widgets history.

The useEffect was was refactored to support receiving this information.

The local state for the widget was refactored to manage the widgets information and history.